### PR TITLE
Index: Restoring Calendar Links and Amending Text

### DIFF
--- a/_data/menu.yaml
+++ b/_data/menu.yaml
@@ -1,8 +1,8 @@
 toc:
     - title: Home
       url: /
-    # - title: Calendar
-    #   url: /Calendar.html
+    - title: Calendar
+      url: /Calendar.html
     - title: Board Games
       subfolderitems:
         - title: By style

--- a/index.md
+++ b/index.md
@@ -17,10 +17,10 @@ We aim to cover:
 In light of the government’s recent recommendations around COVID-19 (aka coronavirus), we have decided to have a hiatus for St Ives Tabletop until further notice.
 We are keen to restart the club as and when the advice changes and will keep you updated via our various [communication channels](/Contact.html).
 
-For those who would like to continue during this break to play either board games or role-playing games, we are hoping to organise some virtual sessions in place of the regular Wednesday fortnightly sessions (e.g. using [Tabletop Simulator](https://www.tabletopsimulator.com) or various websites for board games, [Roll20](https://roll20.net) for tabletop RPGs, with [Discord][Discord] as voice/video chat).
+For those who would like to continue during this break to play either board games or role-playing games, we are organising some virtual sessions in place of the regular Wednesday fortnightly sessions (e.g. using [Tabletop Simulator](https://www.tabletopsimulator.com) or various websites for board games, [Roll20](https://roll20.net) for tabletop RPGs, with [Discord][Discord] as voice/video chat).
 If you are interested in joining, please join our [Discord][Discord] server and please let us know so we can organise.
 
-{% comment %}
+The next virtual session will be:  
 *{%- case d %}
 	{%- when "1" or "21" or "31" %}{{ d }}st
 	{%- when "2" or "22" %}{{ d }}nd
@@ -28,8 +28,7 @@ If you are interested in joining, please join our [Discord][Discord] server and 
 	{%- else %}{{ d }}th
 {%- endcase %} {{ site.data.SessionInformation.NextSessionDate | date: "%B %Y" }} @ {{ site.data.SessionInformation.SessionStart | date: "%l:%M%P" }} until {{ site.data.SessionInformation.SessionEnd | date: "%l:%M%P"}}*
 
-See the [calendar](/Calendar.html) for the following sessions.
-{% endcomment %}
+See the [calendar](/Calendar.html) for the following sessions (which will be virtual until further notice).
 
 ![Poster](/images/Poster_OnHiatus.png){:class="img_poster"}
 


### PR DESCRIPTION
I've amended the Google Calendar to have "Virtual St Ives Tabletop" entries for the forseeable future.  So then we can restore the calendar link.

When you Jekyll serve the page, what do you think about readding the next date back in too?

Also, thoughts on if I should amend the poster image to have "Next Virtual Date: [DATE]" instead of the "On Hiatus" blurb?